### PR TITLE
Adds deltaTime support and example

### DIFF
--- a/src/Project.Library/Application.cpp
+++ b/src/Project.Library/Application.cpp
@@ -31,12 +31,12 @@ void Application::Run()
     spdlog::info("App: Loaded");
 
     //deltaTime = 0.0;
-    double prevTime = glfwGetTime();
+    double previousTime = glfwGetTime();
     while (!glfwWindowShouldClose(_windowHandle))
     {
-        double currTime = glfwGetTime();
-        float deltaTime = static_cast<float>(currTime - prevTime);
-        prevTime = currTime;
+        double currentTime = glfwGetTime();
+        float deltaTime = static_cast<float>(currentTime - previousTime);
+        previousTime = currentTime;
 
         glfwPollEvents();
         Update(deltaTime);

--- a/src/Project.Library/Application.cpp
+++ b/src/Project.Library/Application.cpp
@@ -30,7 +30,6 @@ void Application::Run()
 
     spdlog::info("App: Loaded");
 
-    //deltaTime = 0.0;
     double previousTime = glfwGetTime();
     while (!glfwWindowShouldClose(_windowHandle))
     {

--- a/src/Project.Library/Application.cpp
+++ b/src/Project.Library/Application.cpp
@@ -30,8 +30,14 @@ void Application::Run()
 
     spdlog::info("App: Loaded");
 
+    deltaTime = 0.0;
+    double prevFrame = glfwGetTime();
     while (!glfwWindowShouldClose(_windowHandle))
     {
+        double curFrame = glfwGetTime();
+        deltaTime = curFrame - prevFrame;
+        prevFrame = curFrame;
+
         glfwPollEvents();
         Update();
         Render();
@@ -53,6 +59,11 @@ void Application::Close()
 bool Application::IsKeyPressed(int32_t key)
 {
     return glfwGetKey(_windowHandle, key) == GLFW_PRESS;
+}
+
+double Application::GetDeltaTime()
+{
+    return deltaTime;
 }
 
 bool Application::Initialize()
@@ -159,10 +170,12 @@ void Application::RenderScene()
 
 void Application::RenderUI()
 {
+
 }
 
 void Application::Update()
 {
+
 }
 
 void Application::AfterCreatedUiContext()

--- a/src/Project.Library/Application.cpp
+++ b/src/Project.Library/Application.cpp
@@ -30,17 +30,17 @@ void Application::Run()
 
     spdlog::info("App: Loaded");
 
-    deltaTime = 0.0;
-    double prevFrame = glfwGetTime();
+    //deltaTime = 0.0;
+    double prevTime = glfwGetTime();
     while (!glfwWindowShouldClose(_windowHandle))
     {
-        double curFrame = glfwGetTime();
-        deltaTime = curFrame - prevFrame;
-        prevFrame = curFrame;
+        double currTime = glfwGetTime();
+        float deltaTime = static_cast<float>(currTime - prevTime);
+        prevTime = currTime;
 
         glfwPollEvents();
-        Update();
-        Render();
+        Update(deltaTime);
+        Render(deltaTime);
     }
 
     spdlog::info("App: Unloading");
@@ -59,11 +59,6 @@ void Application::Close()
 bool Application::IsKeyPressed(int32_t key)
 {
     return glfwGetKey(_windowHandle, key) == GLFW_PRESS;
-}
-
-double Application::GetDeltaTime()
-{
-    return deltaTime;
 }
 
 bool Application::Initialize()
@@ -146,16 +141,16 @@ void Application::Unload()
     glfwTerminate();
 }
 
-void Application::Render()
+void Application::Render(float dt)
 {
     ZoneScopedC(tracy::Color::Red2);
 
-    RenderScene();
+    RenderScene(dt);
     ImGui_ImplOpenGL3_NewFrame();
     ImGui_ImplGlfw_NewFrame();
     ImGui::NewFrame();
     {
-        RenderUI();
+        RenderUI(dt);
         ImGui::Render();
         ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
         ImGui::EndFrame();
@@ -164,16 +159,16 @@ void Application::Render()
     glfwSwapBuffers(_windowHandle);
 }
 
-void Application::RenderScene()
+void Application::RenderScene([[maybe_unused]] float dt)
 {
 }
 
-void Application::RenderUI()
+void Application::RenderUI([[maybe_unused]] float dt )
 {
 
 }
 
-void Application::Update()
+void Application::Update([[maybe_unused]] float dt )
 {
 
 }

--- a/src/Project.Library/include/Project.Library/Application.hpp
+++ b/src/Project.Library/include/Project.Library/Application.hpp
@@ -19,13 +19,13 @@ protected:
     virtual bool Initialize();
     virtual bool Load();
     virtual void Unload();
-    virtual void RenderScene(float dt);
-    virtual void RenderUI(float dt);
-    virtual void Update(float dt);
+    virtual void RenderScene(float deltaTime);
+    virtual void RenderUI(float deltaTime);
+    virtual void Update(float deltaTime);
 
 
 private:
     GLFWwindow* _windowHandle = nullptr;
-    void Render(float dt);
+    void Render(float deltaTime);
 
 };

--- a/src/Project.Library/include/Project.Library/Application.hpp
+++ b/src/Project.Library/include/Project.Library/Application.hpp
@@ -11,6 +11,9 @@ public:
 protected:
     void Close();
     bool IsKeyPressed(int32_t key);
+    
+    double GetDeltaTime();
+
     virtual void AfterCreatedUiContext();
     virtual void BeforeDestroyUiContext();
     virtual bool Initialize();
@@ -20,7 +23,12 @@ protected:
     virtual void RenderUI();
     virtual void Update();
 
+
 private:
     GLFWwindow* _windowHandle = nullptr;
     void Render();
+
+    //elapsed time between frames in seconds, used to allow framerate independent timing calculations
+    double deltaTime;
+
 };

--- a/src/Project.Library/include/Project.Library/Application.hpp
+++ b/src/Project.Library/include/Project.Library/Application.hpp
@@ -19,16 +19,13 @@ protected:
     virtual bool Initialize();
     virtual bool Load();
     virtual void Unload();
-    virtual void RenderScene();
-    virtual void RenderUI();
-    virtual void Update();
+    virtual void RenderScene(float dt);
+    virtual void RenderUI(float dt);
+    virtual void Update(float dt);
 
 
 private:
     GLFWwindow* _windowHandle = nullptr;
-    void Render();
-
-    //elapsed time between frames in seconds, used to allow framerate independent timing calculations
-    double deltaTime;
+    void Render(float dt);
 
 };

--- a/src/Project/ProjectApplication.cpp
+++ b/src/Project/ProjectApplication.cpp
@@ -92,6 +92,8 @@ void ProjectApplication::Update()
     {
         Close();
     }
+
+    elapsedTime += GetDeltaTime();
 }
 
 void ProjectApplication::RenderScene()
@@ -185,6 +187,7 @@ void ProjectApplication::RenderUI()
     ImGui::Begin("Window");
     {
         ImGui::TextUnformatted("Hello World!");
+        ImGui::Text("Time in seconds since startup: %f", elapsedTime);
         ImGui::End();
     }
 

--- a/src/Project/ProjectApplication.cpp
+++ b/src/Project/ProjectApplication.cpp
@@ -86,17 +86,17 @@ bool ProjectApplication::Load()
     return true;
 }
 
-void ProjectApplication::Update()
+void ProjectApplication::Update([[maybe_unused]]float dt)
 {
     if (IsKeyPressed(GLFW_KEY_ESCAPE))
     {
         Close();
     }
 
-    elapsedTime += GetDeltaTime();
+    _elapsedTime += dt;
 }
 
-void ProjectApplication::RenderScene()
+void ProjectApplication::RenderScene([[maybe_unused]] float dt)
 {
     const auto projection = glm::perspective(glm::radians(80.0f), 1920.0f / 1080.0f, 0.1f, 256.0f);
     const auto view = glm::lookAt(
@@ -182,12 +182,12 @@ void ProjectApplication::RenderScene()
     }
 }
 
-void ProjectApplication::RenderUI()
+void ProjectApplication::RenderUI([[maybe_unused]] float dt )
 {
     ImGui::Begin("Window");
     {
         ImGui::TextUnformatted("Hello World!");
-        ImGui::Text("Time in seconds since startup: %f", elapsedTime);
+        ImGui::Text("Time in seconds since startup: %f", _elapsedTime);
         ImGui::End();
     }
 

--- a/src/Project/ProjectApplication.cpp
+++ b/src/Project/ProjectApplication.cpp
@@ -86,17 +86,17 @@ bool ProjectApplication::Load()
     return true;
 }
 
-void ProjectApplication::Update([[maybe_unused]]float dt)
+void ProjectApplication::Update(float deltaTime)
 {
     if (IsKeyPressed(GLFW_KEY_ESCAPE))
     {
         Close();
     }
 
-    _elapsedTime += dt;
+    _elapsedTime += deltaTime;
 }
 
-void ProjectApplication::RenderScene([[maybe_unused]] float dt)
+void ProjectApplication::RenderScene([[maybe_unused]] float deltaTime)
 {
     const auto projection = glm::perspective(glm::radians(80.0f), 1920.0f / 1080.0f, 0.1f, 256.0f);
     const auto view = glm::lookAt(
@@ -182,12 +182,13 @@ void ProjectApplication::RenderScene([[maybe_unused]] float dt)
     }
 }
 
-void ProjectApplication::RenderUI([[maybe_unused]] float dt )
+void ProjectApplication::RenderUI(float deltaTime)
 {
     ImGui::Begin("Window");
     {
         ImGui::TextUnformatted("Hello World!");
         ImGui::Text("Time in seconds since startup: %f", _elapsedTime);
+        ImGui::Text("The delta time between frames: %f", deltaTime);
         ImGui::End();
     }
 

--- a/src/Project/include/Project/ProjectApplication.hpp
+++ b/src/Project/include/Project/ProjectApplication.hpp
@@ -71,15 +71,15 @@ protected:
     void AfterCreatedUiContext() override;
     void BeforeDestroyUiContext() override;
     bool Load() override;
-    void RenderScene() override;
-    void RenderUI() override;
-    void Update() override;
+    void RenderScene(float dt) override;
+    void RenderUI(float dt) override;
+    void Update(float dt) override;
 
 private:
     Model _cubes;
     uint32_t _shaderProgram;
 
-    double elapsedTime = 0.0;
+    float _elapsedTime = 0.0f;
 
     bool MakeShader(std::string_view vertexShaderFilePath, std::string_view fragmentShaderFilePath);
     void LoadModel(std::string_view filePath);

--- a/src/Project/include/Project/ProjectApplication.hpp
+++ b/src/Project/include/Project/ProjectApplication.hpp
@@ -79,6 +79,8 @@ private:
     Model _cubes;
     uint32_t _shaderProgram;
 
+    double elapsedTime = 0.0;
+
     bool MakeShader(std::string_view vertexShaderFilePath, std::string_view fragmentShaderFilePath);
     void LoadModel(std::string_view filePath);
 };

--- a/src/Project/include/Project/ProjectApplication.hpp
+++ b/src/Project/include/Project/ProjectApplication.hpp
@@ -71,9 +71,9 @@ protected:
     void AfterCreatedUiContext() override;
     void BeforeDestroyUiContext() override;
     bool Load() override;
-    void RenderScene(float dt) override;
-    void RenderUI(float dt) override;
-    void Update(float dt) override;
+    void RenderScene(float deltaTime) override;
+    void RenderUI(float deltaTime) override;
+    void Update(float deltaTime) override;
 
 private:
     Model _cubes;


### PR DESCRIPTION
The current CMake-GLfw-OpenGL-Template does not show the use of deltaTime, the elapsed time between frames, for framerate independent calculations. This is a very commonly used functionality, and so I decided to make a fork of it. 

This method uses a Getter method to retrieve deltaTime(). Other examples, such as Fwog, passes in deltaTime as a parameter to `Update()` type functions, but I chose a getter as inspired by [Unity's Time.deltaTime](https://docs.unity3d.com/ScriptReference/Time-deltaTime.html) and more details under [Unity Time Frame Management](https://docs.unity3d.com/Manual/TimeFrameManagement.html) as one example.

Another option could be to have a static deltaTime variable or a protected one accessible by child members, but I figured a getter might be a better starting point despite the minor overhead due to being quite explict that deltaTime is managed by the parent library.
