### PR TITLE
Add instructions for Deccer's Cubes regarding git submodules

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ some mesh rendering and texture loading, `spdlog` unifies logging here - as each
 - for VSCode the `CMake Tools` extension from Microsoft
 - a compiler of your choice (Clang, GCC, MSVC)
 
+Make sure to run `git submodule update --init --recursive` upon cloning the repository to ensure that Deccer's Cubes are included.
+
 ## Assumptions
 
 This project template assumes the following things


### PR DESCRIPTION
The current version of the Readme does not mention that the models folder uses a git submodule for Deccer's Cubes. This will cause the models to be missed upon running the program and some users may not notice that this is the reason why.

More information can be found in this stackoverflow page: [Pull latest changes for all git submodules](https://stackoverflow.com/a/27431025).